### PR TITLE
Fix broken AQI link, add forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Burn Boise
 
-A simple Sinatra app that takes the [Air Quality Index (AQI)](https://airnow.gov/) and compares it with [Boise local ordinances](http://www2.deq.idaho.gov/air/AQIPublic/Ordinance/Index/3) to let you know whether current are within ordinances based off of forecasts.
+A simple Sinatra app that takes the [Air Quality Index (AQI)](https://airnow.gov/) and compares it with [Boise local ordinances](http://www2.deq.idaho.gov/air/AQIPublic/Ordinance/Index/3) to let you know whether current conditions are within ordinances based off of forecasts.
 
 DISCLAIMER: Official restrictions are served [here](http://www2.deq.idaho.gov/air/AQIPublic/Forecast?siteId=14). *Furthermore, prohibitions are based off of the forecast, not actual conditions.* That is, an AQI lower than forecase does not necessarily mean it is okay for you to burn. For more information on open burning requirements, please contact your local city or county office.
 

--- a/burn_boise.rb
+++ b/burn_boise.rb
@@ -5,7 +5,7 @@ require './lib/regulations'
 
 get '/' do
   zipcode = params[:zipcode] || "83704"
-  aqi = get_aqi(zipcode)
+  aqi, url = get_aqi(zipcode)
 
   prohibited = Regulations.prohibited_reactors(zipcode, aqi)
 

--- a/erb/index.html.erb
+++ b/erb/index.html.erb
@@ -30,6 +30,7 @@
       <footer class="w-100 fixed pa3 center">
         <small class="w-50 center flex dark-gray o-70">
           <a class="link tracked center" href="https://github.com/0xtobit/burn-boise">@0xtobit</a>
+          <a class="link tracked center" href="http://www2.deq.idaho.gov/air/AQIPublic/Forecast?siteId=14">forecast</a>
           <a class="link tracked center" href="http://www2.deq.idaho.gov/air/AQIPublic/Ordinance/Index/3">rules</a>
         </small>
       </footer>

--- a/lib/aqi.rb
+++ b/lib/aqi.rb
@@ -6,5 +6,5 @@ def get_aqi(zipcode)
   doc = HTTParty.get(url)
   parsed_page ||= Nokogiri::HTML(doc)
   aqi = parsed_page.css('.TblInvisible')[0].text[/\d+/].to_i
-  aqi
+  [aqi, url]
 end


### PR DESCRIPTION
Update typo in README. `url` for `get '/'` was not the forecast URL but
`/`.